### PR TITLE
fix: resolve code quality issues and bugs across services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Claude Code local context (personal/machine-specific)
+.claude/

--- a/apps/commitments/src/commitments.outbox.ts
+++ b/apps/commitments/src/commitments.outbox.ts
@@ -33,7 +33,7 @@ export class CommitmentsOutboxProcessor extends DefaultOutboxProcessor {
     for (const event of pendingEvents) {
       try {
         switch (event.eventType) {
-          case 'getAgregatedDataByListingId': {
+          case 'getAggregatedDataByListingId': {
             const payload = event.payload as {
               userId: string;
               listingId: string;
@@ -132,6 +132,7 @@ export class CommitmentsOutboxProcessor extends DefaultOutboxProcessor {
                 await manager.getRepository(TransactionalOutbox).save(event);
               },
             );
+            break;
           }
 
           case 'closeExpiredCommitment': {
@@ -150,6 +151,7 @@ export class CommitmentsOutboxProcessor extends DefaultOutboxProcessor {
                 await manager.getRepository(TransactionalOutbox).save(event);
               },
             );
+            break;
           }
 
           default:

--- a/apps/commitments/src/commitments.service.ts
+++ b/apps/commitments/src/commitments.service.ts
@@ -55,7 +55,7 @@ export class CommitmentsService {
         },
       ),
     );
-    console.log(listing);
+    this.logger.log(`commitment_create - fetched listing: ${listing.id}`);
     listing.entryFee = new Decimal(listing.entryFee);
     // get buyer information
     const buyer: User = await firstValueFrom(
@@ -325,6 +325,7 @@ export class CommitmentsService {
   async cancelCommitment(buyerId: string, id: string, manager?: EntityManager) {
     if (manager) {
       await this.cancelCommitmentWithLock(buyerId, id, manager);
+      return;
     }
     await this.commitmentRepository.manager.transaction(async (manager) => {
       await this.cancelCommitmentWithLock(buyerId, id, manager);

--- a/apps/gateway/src/consumers/index.ts
+++ b/apps/gateway/src/consumers/index.ts
@@ -1,1 +1,2 @@
 export * from './listings.consumer';
+export * from './commitments.consumer';

--- a/apps/gateway/src/consumers/listings.consumer.ts
+++ b/apps/gateway/src/consumers/listings.consumer.ts
@@ -34,7 +34,7 @@ export class ListingsConsumer extends WorkerHost {
             await manager.getRepository(TransactionalOutbox).save(
               manager.getRepository(TransactionalOutbox).create({
                 channel: COMMITMENTS_OUTBOX_CHANNEL,
-                eventType: 'getAgregatedDataByListingId',
+                eventType: 'getAggregatedDataByListingId',
                 payload: {
                   userId: sellerId,
                   listingId,

--- a/apps/gateway/src/gateway.module.ts
+++ b/apps/gateway/src/gateway.module.ts
@@ -26,6 +26,8 @@ import { ListingsConsumer } from './consumers';
 import { TransactionalOutboxModule } from '@app/common';
 import { DatabaseModule } from '@app/common/database/database.module';
 import { CommitmentsConsumer } from './consumers/commitments.consumer';
+import { BmqModule } from '@app/common/bullmq/bullmq.module';
+import { COMMITMENT_BMQ, LISTING_BMQ } from '@app/common';
 
 @Module({
   imports: [
@@ -115,6 +117,7 @@ import { CommitmentsConsumer } from './consumers/commitments.consumer';
     AuthGatewayModule,
     DatabaseModule,
     TransactionalOutboxModule,
+    BmqModule.register([LISTING_BMQ, COMMITMENT_BMQ]),
   ],
   controllers: [
     GatewayController,

--- a/apps/listings/src/listings.outbox.ts
+++ b/apps/listings/src/listings.outbox.ts
@@ -121,6 +121,34 @@ export class ListingsOutboxProcessor extends DefaultOutboxProcessor {
             break;
           }
 
+          case 'closeExpiredListing': {
+            const payload = event.payload as {
+              id: string;
+            };
+            await this.transactionalOutboxRepository.manager.transaction(
+              async (manager) => {
+                const listing = await manager
+                  .getRepository(ProductListing)
+                  .createQueryBuilder('product_listing')
+                  .setLock('pessimistic_write')
+                  .select(['product_listing.id', 'product_listing.expired'])
+                  .where('product_listing.id = :id', { id: payload.id })
+                  .getOne();
+
+                if (!listing) {
+                  throw new Error('Product listing not found');
+                }
+
+                listing.expired = true;
+                await manager.getRepository(ProductListing).save(listing);
+
+                event.processed = true;
+                await manager.getRepository(TransactionalOutbox).save(event);
+              },
+            );
+            break;
+          }
+
           default:
             break;
         }

--- a/apps/notifications/src/notifications.service.ts
+++ b/apps/notifications/src/notifications.service.ts
@@ -32,7 +32,7 @@ export class NotificationsService {
       .createQueryBuilder('notification')
       .leftJoin('notification.user', 'user')
       .addSelect('user.id')
-      .where('user.id := userId', { userId })
+      .where('user.id = :userId', { userId })
       .getMany();
   }
 }

--- a/apps/orders/src/orders.outbox.ts
+++ b/apps/orders/src/orders.outbox.ts
@@ -95,6 +95,7 @@ export class OrdersOutboxProcessor extends DefaultOutboxProcessor {
                 await manager.getRepository(TransactionalOutbox).save(event);
               },
             );
+            break;
           }
 
           case 'closeCommitment': {

--- a/apps/orders/src/orders.service.ts
+++ b/apps/orders/src/orders.service.ts
@@ -1,6 +1,7 @@
 import {
   ForbiddenException,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { CreateOrderDto } from './dto/create-order.dto';
@@ -11,6 +12,7 @@ import { OrderStatus } from '@app/common/enums/order-status.enum';
 
 @Injectable()
 export class OrdersService {
+  private readonly logger = new Logger(OrdersService.name);
   constructor(
     @InjectRepository(Order)
     private readonly ordersRepository: Repository<Order>,
@@ -28,11 +30,16 @@ export class OrdersService {
         manager,
         true,
       );
-      // if an order with the given commitment Id exists already, then throw error
+      // if an order with the given commitment Id exists already, throw to block creation
       throw new ForbiddenException(
         'Order with the given commitment ID already exist!',
       );
-    } catch {}
+    } catch (error) {
+      if (!(error instanceof NotFoundException)) {
+        throw error;
+      }
+      // NotFoundException means no order exists yet — safe to proceed
+    }
 
     const order = await repo.create({
       ...createOrderDto,

--- a/apps/payments/src/payments.service.ts
+++ b/apps/payments/src/payments.service.ts
@@ -3,6 +3,7 @@ import {
   Inject,
   Injectable,
   InternalServerErrorException,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -24,6 +25,7 @@ import { User } from 'apps/users/src/entities/user.entity';
 @Injectable()
 export class PaymentsService {
   private stripe: Stripe;
+  private readonly logger = new Logger(PaymentsService.name);
 
   constructor(
     private readonly configService: ConfigService,
@@ -175,34 +177,32 @@ export class PaymentsService {
     );
     // need to check if user creating the payment is the one from commitment
     // TODO: create new function for this in order microservice
-    const [payment, stripeSessionUrl]: [Payment | null, string | null] =
+    // Check if a non-expired payment already exists for this commitment.
+    // If a pending session is still open, return its URL directly.
+    const existingSessionUrl: string | null =
       await this.paymentsRepository.manager.transaction(async (manager) => {
-        // 0: check if a PENDING payment exist with this commitmentId
-        // if exist the pending payment, return its stripe session id / url IF the session has not expired, a.k.a open
-
         const payment = await this.findOneOpenPaymentByCommitmentId(
           commitmentId,
           manager,
           true,
         );
-        if (payment.status == PaymentStatus.Pending) {
+        if (payment.status === PaymentStatus.Pending) {
           const session = await this.stripe.checkout.sessions.retrieve(
             payment.stripeFinalPaymentSessionId,
           );
           if (session.status === 'open') {
-            return [null, session.url];
+            return session.url;
           }
         } else if (payment.status === PaymentStatus.Success) {
           throw new ForbiddenException(
             'Payment for this commitment ID has been processed!',
           );
         }
-
-        return [payment, null];
+        return null;
       });
 
-    if (stripeSessionUrl) {
-      return stripeSessionUrl;
+    if (existingSessionUrl) {
+      return existingSessionUrl;
     }
     let session: Stripe.Checkout.Session = null;
     try {
@@ -255,7 +255,7 @@ export class PaymentsService {
     } catch (error) {
       // set payment status to failed in DB if this stripe API call fails
       // TODO: DON'T SET payment status if call to API fails, just throw error so next time can call again
-      console.log('error creating session');
+      this.logger.error(`createHostedPayment - Failed to create Stripe session: ${error.message}`);
       // await this.paymentsRepository.update(
       //   {
       //     id: payment.id,
@@ -268,19 +268,39 @@ export class PaymentsService {
         `Error creating Stripe embedded form: ${error.message}`,
       );
     }
-    // update the payment info with Stripe's session ID and amount total
-    // and set its status to Pending
-    payment.stripeFinalPaymentSessionId = session.id;
-    payment.finalAmount = commitment.listing.finalPrice
-      .times(commitment.quantity)
-      .times(100)
-      .ceil()
-      .div(100);
-    payment.status = PaymentStatus.Pending;
+    // Update the payment with the new session inside a locked transaction.
+    // If a concurrent request already claimed this payment, expire our
+    // newly created session and return the existing open session URL instead.
+    const finalUrl = await this.paymentsRepository.manager.transaction(
+      async (manager) => {
+        const paymentToUpdate = await this.findOneOpenPaymentByCommitmentId(
+          commitmentId,
+          manager,
+          true,
+        );
 
-    await this.paymentsRepository.save(payment);
+        if (paymentToUpdate.status === PaymentStatus.Pending) {
+          // Another concurrent request beat us to it — clean up our orphaned session
+          await this.stripe.checkout.sessions.expire(session.id);
+          const existingSession = await this.stripe.checkout.sessions.retrieve(
+            paymentToUpdate.stripeFinalPaymentSessionId,
+          );
+          return existingSession.url;
+        }
 
-    return session.url;
+        paymentToUpdate.stripeFinalPaymentSessionId = session.id;
+        paymentToUpdate.finalAmount = commitment.listing.finalPrice
+          .times(commitment.quantity)
+          .times(100)
+          .ceil()
+          .div(100);
+        paymentToUpdate.status = PaymentStatus.Pending;
+        await manager.getRepository(Payment).save(paymentToUpdate);
+        return session.url;
+      },
+    );
+
+    return finalUrl;
   }
 
   async getPaymentStatus(paymentId: string, manager?: EntityManager) {

--- a/apps/webhook/src/stripe/stripe.webhook.service.ts
+++ b/apps/webhook/src/stripe/stripe.webhook.service.ts
@@ -52,46 +52,51 @@ export class StripeWebhookService {
           const session = event.data.object as Stripe.Checkout.Session;
           const action = session.metadata.action;
           if (action === 'createEntryFeeCheckoutSession') {
-            // update payment row to have status entry_paid and add their entry fee payment intent ID
-            await this.transactionalOutboxRepository.save(
-              this.transactionalOutboxRepository.create({
-                channel: PAYMENTS_OUTBOX_CHANNEL,
-                eventType: 'entryFeeCheckoutSessionSuccess',
-                payload: {
-                  sessionId: session.id,
-                  paymentIntentId: session.payment_intent.toString(),
-                },
-              }),
-            );
+            // Idempotency: skip if this session was already enqueued
+            const duplicate = await this.transactionalOutboxRepository
+              .createQueryBuilder('outbox')
+              .where('outbox.channel = :channel', { channel: PAYMENTS_OUTBOX_CHANNEL })
+              .andWhere('outbox.eventType = :eventType', { eventType: 'entryFeeCheckoutSessionSuccess' })
+              .andWhere("outbox.payload->>'sessionId' = :sessionId", { sessionId: session.id })
+              .getOne();
+            if (!duplicate) {
+              // update payment row to have status entry_paid and add their entry fee payment intent ID
+              await this.transactionalOutboxRepository.save(
+                this.transactionalOutboxRepository.create({
+                  channel: PAYMENTS_OUTBOX_CHANNEL,
+                  eventType: 'entryFeeCheckoutSessionSuccess',
+                  payload: {
+                    sessionId: session.id,
+                    paymentIntentId: session.payment_intent.toString(),
+                  },
+                }),
+              );
+            }
           } else if (action === 'createFinalPaymentCheckoutSession') {
-            // Once payment succeeded, create order object and update payment object
-            await this.transactionalOutboxRepository.save(
-              this.transactionalOutboxRepository.create({
-                channel: ORDERS_OUTBOX_CHANNEL,
-                eventType: 'finalPaymentCheckoutSessionSuccess',
-                payload: {
-                  amount_total: session.amount_total,
-                  shipping_address: session.shipping_details.address,
-                  commitmentId: session.metadata.commitmentId,
-                  buyerId: session.metadata.buyerId,
-                  sessionId: session.id,
-                  paymentIntentId: session.payment_intent.toString(),
-                },
-              }),
-            );
-            //   await firstValueFrom(
-            //     this.paymentsMicroservice.send(
-            //       {
-            //         cmd: 'handlePaymentSessionSuccess',
-            //       },
-            //       {
-            //         session,
-            //       },
-            //     ),
-            //     {
-            //       defaultValue: null,
-            //     },
-            //   );
+            // Idempotency: skip if this session was already enqueued
+            const duplicate = await this.transactionalOutboxRepository
+              .createQueryBuilder('outbox')
+              .where('outbox.channel = :channel', { channel: ORDERS_OUTBOX_CHANNEL })
+              .andWhere('outbox.eventType = :eventType', { eventType: 'finalPaymentCheckoutSessionSuccess' })
+              .andWhere("outbox.payload->>'sessionId' = :sessionId", { sessionId: session.id })
+              .getOne();
+            if (!duplicate) {
+              // Once payment succeeded, create order object and update payment object
+              await this.transactionalOutboxRepository.save(
+                this.transactionalOutboxRepository.create({
+                  channel: ORDERS_OUTBOX_CHANNEL,
+                  eventType: 'finalPaymentCheckoutSessionSuccess',
+                  payload: {
+                    amount_total: session.amount_total,
+                    shipping_address: session.shipping_details.address,
+                    commitmentId: session.metadata.commitmentId,
+                    buyerId: session.metadata.buyerId,
+                    sessionId: session.id,
+                    paymentIntentId: session.payment_intent.toString(),
+                  },
+                }),
+              );
+            }
           }
 
           // TODO: log / send out notification that payment succeeded


### PR DESCRIPTION
- Fix typo getAgregatedDataByListingId → getAggregatedDataByListingId in listings consumer and commitments outbox
- Add missing break statements in commitments outbox switch cases
- Fix SQL query syntax bug in notifications service (`:= userId` → `= :userId`)
- Fix silent catch block in orders service to only suppress NotFoundException
- Add early return in commitments service cancelCommitment to prevent double execution
- Replace console.log with proper Logger calls in commitments and payments services
- Fix race condition in payments service by wrapping session assignment in locked transaction
- Add idempotency checks in stripe webhook service to prevent duplicate outbox entries
- Add missing closeExpiredListing case in listings outbox processor
- Add BmqModule import and CommitmentsConsumer export to gateway module